### PR TITLE
Add Dockerfile and update README for Docker usage

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "build": "python3 install.py",
+    "test": "python3 GeoTrackerIP.py --help"
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use python:3.8-slim as the base image
+FROM python:3.8-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the GeoTrackerIP.py and install.py files into the Docker image
+COPY GeoTrackerIP.py install.py /app/
+
+# Run the install.py script to install dependencies
+RUN python3 install.py
+
+# Set the entrypoint to GeoTrackerIP.py
+ENTRYPOINT ["python3", "GeoTrackerIP.py"]

--- a/README.md
+++ b/README.md
@@ -57,5 +57,18 @@ Puedes pasar como argumento la URL o la dirección IP del objetivo.
 python3 GeoTrackerIP.py -t https://example.com
 ```
 
+## Docker
+### Construir la imagen de Docker
+Para construir la imagen de Docker, navega al directorio del proyecto y ejecuta el siguiente comando:
+```bash
+docker build -t geotrackerip .
+```
+
+### Ejecutar el contenedor de Docker
+Para ejecutar el contenedor de Docker, usa el siguiente comando:
+```bash
+docker run --rm geotrackerip -t https://example.com
+```
+
 ## Licencia
 GeoTrackerIP está hecho con 💚 por JRIC2002. Vea el archivo de **Licencia** para más detalles.


### PR DESCRIPTION
Add Docker support for GeoTrackerIP tool

* **Dockerfile**
  - Create a `Dockerfile` to build the Docker image using `python:3.8-slim` as the base image
  - Copy `GeoTrackerIP.py` and `install.py` files into the Docker image
  - Run `install.py` script to install dependencies
  - Set the entrypoint to `GeoTrackerIP.py`

* **README.md**
  - Add a section for building the Docker image
  - Add a section for running the Docker container
  - Update installation instructions to include Docker usage

* **.devcontainer/devcontainer.json**
  - Add a devcontainer configuration file with build and test tasks

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yacosta738/GeoTrackerIP/pull/1?shareId=e6399316-15dd-4696-8819-230664cb1a37).